### PR TITLE
UDP Pseudo header에 채워지던 length값의 byte order방식 변경

### DIFF
--- a/IPLayer.cpp
+++ b/IPLayer.cpp
@@ -138,7 +138,7 @@ BOOL CIPLayer::Receive(unsigned char* ppayload,int dev_num)
 	if (pFrame->Ip_protocol == 0x11)  // udp protocol (17) 확인
 	{ 
 		SetSrcIPForRIPLayer(pFrame->Ip_srcAddressByte, dev_num);
-		((CUDPLayer*)GetUpperLayer(0))->SetReceivePseudoHeader( pFrame->Ip_srcAddressByte, pFrame->Ip_dstAddressByte, (unsigned short)ntohs(pFrame->Ip_len) - IP_HEADER_SIZE );
+		((CUDPLayer*)GetUpperLayer(0))->SetReceivePseudoHeader( pFrame->Ip_srcAddressByte, pFrame->Ip_dstAddressByte, (unsigned short)htons(ntohs(pFrame->Ip_len) - IP_HEADER_SIZE) );
 		return GetUpperLayer(0)->Receive((unsigned char *)pFrame->Ip_data, dev_num);
 	}
 	/*else { // else 부분 수정 필요 ( RIP가 아닌 일반 ip 패킷일 때 어떻게 해야할지)

--- a/UDPLayer.cpp
+++ b/UDPLayer.cpp
@@ -126,7 +126,7 @@ BOOL CUDPLayer::Send(unsigned char* ppayload, int nlength, int dev_num)
 	routerDlg->m_IPLayer->SetProtocol(0x11, dev_num);
 
 	Udp_header.Udp_length = (unsigned short) htons(nlength);
-	SetSendPseudoHeader((unsigned short) nlength, dev_num);
+	SetSendPseudoHeader((unsigned short) htons(nlength), dev_num);
 	Udp_header.Udp_checksum = (unsigned short) htons(SetChecksum(nlength));
 
 	BOOL bSuccess = mp_UnderLayer->Send((unsigned char*)&Udp_header, nlength, dev_num);


### PR DESCRIPTION
UDP pseudo header에 채우던 length(unsigned short)값의 byte order를 host's order에서 networks' order로 바꿈.
