### PR TITLE
Fix error and Add comment

### DIFF
--- a/RouterDlg.cpp
+++ b/RouterDlg.cpp
@@ -68,7 +68,6 @@ CRouterDlg::CRouterDlg(CWnd* pParent /*=NULL*/)
 	m_EthernetLayer->SetUpperLayer(m_ARPLayer);
 	m_EthernetLayer->SetUnderLayer(m_NILayer);
 	m_ARPLayer->SetUnderLayer(m_EthernetLayer);
-	m_ARPLayer->SetUpperLayer(m_IPLayer);
 	m_IPLayer->SetUpperLayer(m_UDPLayer);
 	m_IPLayer->SetUnderLayer(m_ARPLayer);
 	m_UDPLayer->SetUpperLayer(m_RIPLayer);


### PR DESCRIPTION
m_ARPLayer->SetUpperLayer(m_IPLayer);

I think it is unnecessary code, because ARP send message just Ethernet layer not IP layer.

And we already get routerDlg object using following code in ARPLayer.cpp.
CRouterDlg \* routerDlg =  ((CRouterDlg *)(GetUnderLayer()->GetUpperLayer(0)->GetUpperLayer(0)->GetUpperLayer(0)->GetUpperLayer(0)));
